### PR TITLE
build: fix configure failure in gcc-14

### DIFF
--- a/dist/config.pkg
+++ b/dist/config.pkg
@@ -66,6 +66,7 @@ config() {
 #include <sys/types.h>
 #include <stdint.h>
 #include <dirent.h>
+#include <stdio.h>
 
 int main(int argc, char *argv[]) {
 	DIR *dir;
@@ -74,7 +75,7 @@ int main(int argc, char *argv[]) {
 
 	dir = opendir(".");
 	entry = readdir(dir);
-	puts(entry->d_name[0]);
+	puts(entry->d_name);
 	closedir(dir);
 	return 0;
 }


### PR DESCRIPTION
```
$ ./configure
…
Checking for opendir/readdir/closedir/dirent.h/stdint.h... no
!! Some required functionality is not available. See config.log for details.
…
$ cat config.log
.config.c:12:9: error: implicit declaration of function ‘puts’ [-Wimplicit-function-declaration]
// once the right prototype is in view:
.config.c:13:27: error: passing argument 1 of ‘puts’ makes pointer from integer without a cast [-Wint-conversion]
```